### PR TITLE
src/testu01_gateway.cpp: fix `receivedIndex` counter increment

### DIFF
--- a/src/testu01_gateway.cpp
+++ b/src/testu01_gateway.cpp
@@ -73,7 +73,7 @@ inline uint32_t ProxyRng::getUInt32()
         return reverseBits(received[receivedIndex]);
     }
     ++sequenceNumber;
-    return received[receivedIndex];
+    return received[receivedIndex++];
 }
 
 


### PR DESCRIPTION
The counter to index integers in the `received` buffer is not incremented. This PR adds the missing increment.